### PR TITLE
Initial Support for Markdown (Issue 9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # cool_ssg_generator
 A simple SSG generator made with Python.
 Current version is 0.1.0
@@ -42,6 +43,9 @@ For more usage, please refer to:
 ```console
 python main.py -h
 ```
+
+### Features
+* Markdown (.md files) support for **bold** (**), *italics* (*), and [links](https://github.com/lmpham1/cool_ssg_generator).
 
 ### License
 [MIT](LICENSE)

--- a/helper.py
+++ b/helper.py
@@ -5,18 +5,23 @@ import shutil
 def generateFromFile(inFile, output, stylesheets):
     filename = inFile[inFile.replace("\\","/").rfind("/")+1:inFile.rfind(".")]
     print(output)
-    if(inFile.endswith(".txt")):
-        with open(inFile, encoding='utf8') as (file):
-            contents = file.readlines()
+    
+    with open(inFile, encoding='utf8') as (file):
+        contents = file.readlines()
+        
+        if(inFile.endswith(".txt")):
             outContent = createHTMLString(filename, contents, stylesheets)
-
-            if not os.path.exists(output):
-                os.makedirs(output if output.endswith("/") else output + "/")
-            
-            outputFile = open(output + "/" + filename + ".html", "w", encoding="utf-8")
-            outputFile.write(outContent)
-            outputFile.close()
-            print("\"" + filename + ".html\" generated successfully!")
+        elif(inFile.endswith(".md")):
+            outContent = createMarkdownString(filename, contents, stylesheets)
+    
+        if not os.path.exists(output):
+            os.makedirs(output if output.endswith("/") else output + "/")
+        
+        outputFile = open(output + "/" + filename + ".html", "w", encoding="utf-8")
+        outputFile.write(outContent)
+        outputFile.close()
+        print("\"" + filename + ".html\" generated successfully!")
+        
 
 # Generate HTML files with the same structure as the input folder, and export to output folder
 def generateFromDirectory(inDir, output, stylesheets):
@@ -56,6 +61,34 @@ def generateFromDirectory(inDir, output, stylesheets):
     outputFile = open(output + "/index.html", "w", encoding="utf-8")
     outputFile.write(indexHTMLContents)
     outputFile.close()
+    
+def createMarkdownString(filename, contents, stylesheets):
+    title = filename
+    
+    htmlSkeleton= """
+        <!doctype html>
+        <html lang="en">
+            <head>
+                <meta charset="utf-8">
+                <title>{title}</title>
+                <link rel="stylesheet" href="public/stylesheet/default.css">
+                {stylesheets}
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+            </head>
+            <body>
+            {contents}
+            </body>
+        </html>    
+    """
+
+    styleHTML = ""
+    if stylesheets is not None:
+        for stylesheet in stylesheets:
+            styleHTML += "<link rel=\"stylesheet\" href={}>\n".format(stylesheet)
+    
+    transformedContent = ''.join(contents)    
+
+    return htmlSkeleton.format(title=title, contents=transformedContent, stylesheets=styleHTML)
 
 # Create HTML mark up and append the content
 # return the complete HTML mark up for a page

--- a/helper.py
+++ b/helper.py
@@ -63,8 +63,17 @@ def generateFromDirectory(inDir, output, stylesheets):
     outputFile.close()
     
 def createMarkdownString(filename, contents, stylesheets):
+    index = 0
     title = filename
     
+    while index < len(contents):
+        contents[index] = contents[index].strip()
+        if index == 0 and len(contents[index]) != 0 and len(contents[index+1].strip()) == 0 and len(contents[index+2].strip()) == 0:
+            title = contents[0]
+            contents[0] = "<h1>" + contents[0] + "</h1>\n"
+            index = 3
+        index+=1
+        
     htmlSkeleton= """
         <!doctype html>
         <html lang="en">

--- a/helper.py
+++ b/helper.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import re
 
 # Generate HTML file from inFile, and export to output folder
 def generateFromFile(inFile, output, stylesheets):
@@ -63,41 +64,10 @@ def generateFromDirectory(inDir, output, stylesheets):
     outputFile.close()
     
 def createMarkdownString(filename, contents, stylesheets):
-    index = 0
-    title = filename
-    
-    while index < len(contents):
-        contents[index] = contents[index].strip()
-        if index == 0 and len(contents[index]) != 0 and len(contents[index+1].strip()) == 0 and len(contents[index+2].strip()) == 0:
-            title = contents[0]
-            contents[0] = "<h1>" + contents[0] + "</h1>\n"
-            index = 3
-        index+=1
-        
-    htmlSkeleton= """
-        <!doctype html>
-        <html lang="en">
-            <head>
-                <meta charset="utf-8">
-                <title>{title}</title>
-                <link rel="stylesheet" href="public/stylesheet/default.css">
-                {stylesheets}
-                <meta name="viewport" content="width=device-width, initial-scale=1">
-            </head>
-            <body>
-            {contents}
-            </body>
-        </html>    
-    """
-
-    styleHTML = ""
-    if stylesheets is not None:
-        for stylesheet in stylesheets:
-            styleHTML += "<link rel=\"stylesheet\" href={}>\n".format(stylesheet)
-    
-    transformedContent = ''.join(contents)    
-
-    return htmlSkeleton.format(title=title, contents=transformedContent, stylesheets=styleHTML)
+    html = createHTMLString(filename, contents, stylesheets)
+    html = re.sub('\*\*([^\ \*.]{1}.*?)\*\*', r'<strong>\1</strong>', html)
+    html = re.sub('\*([^\ \*.]{1}.*?)\*', r'<em>\1</em>', html)
+    return html
 
 # Create HTML mark up and append the content
 # return the complete HTML mark up for a page

--- a/helper.py
+++ b/helper.py
@@ -69,8 +69,8 @@ def createMarkdownString(filename, contents, stylesheets):
     htmlContent = createHTMLString(filename, contents, stylesheets)
     
     # Parse markdown
-    htmlContent = re.sub('\*\*([^\ \*.]{1}.*?)\*\*', r'<strong>\1</strong>', htmlContent)
-    htmlContent = re.sub('\*([^\ \*.]{1}.*?)\*', r'<em>\1</em>', htmlContent)
+    htmlContent = re.sub('\*\*([^\s\*.]{1}.*?)\*\*|__([^\s_.]{1}.*?)__', r'<strong>\1\2</strong>', htmlContent)
+    htmlContent = re.sub('\*([^\s\*.]{1}.*?)\*|_([^\s\_.]{1}.*?)_', r'<em>\1\2</em>', htmlContent)
     htmlContent = re.sub('\[(.+)\]\((.+)\)', r'<a href="\2">\1</a>', htmlContent)
     
     return htmlContent

--- a/helper.py
+++ b/helper.py
@@ -62,12 +62,18 @@ def generateFromDirectory(inDir, output, stylesheets):
     outputFile = open(output + "/index.html", "w", encoding="utf-8")
     outputFile.write(indexHTMLContents)
     outputFile.close()
-    
+
+# Create HTML from markdown file
 def createMarkdownString(filename, contents, stylesheets):
-    html = createHTMLString(filename, contents, stylesheets)
-    html = re.sub('\*\*([^\ \*.]{1}.*?)\*\*', r'<strong>\1</strong>', html)
-    html = re.sub('\*([^\ \*.]{1}.*?)\*', r'<em>\1</em>', html)
-    return html
+    # Create title, paragraphs, and stylesheet first, like normal
+    htmlContent = createHTMLString(filename, contents, stylesheets)
+    
+    # Parse markdown
+    htmlContent = re.sub('\*\*([^\ \*.]{1}.*?)\*\*', r'<strong>\1</strong>', htmlContent)
+    htmlContent = re.sub('\*([^\ \*.]{1}.*?)\*', r'<em>\1</em>', htmlContent)
+    htmlContent = re.sub('\[(.+)\]\((.+)\)', r'<a href="\2">\1</a>', htmlContent)
+    
+    return htmlContent
 
 # Create HTML mark up and append the content
 # return the complete HTML mark up for a page


### PR DESCRIPTION
A few changes were made to add support for markdown.

### generateFromFile()
I altered generateFromFile() to check the file type *after* opening the file. If the file type is ".txt", it continues the script like normal. If it's ".md", it calls **createMarkdownString()** (see below), which adds extra processing to the base html to parse the markdown for bold, italics, and links. The output file is then created like normal.

```python
# Generate HTML file from inFile, and export to output folder
def generateFromFile(inFile, output, stylesheets):
    filename = inFile[inFile.replace("\\","/").rfind("/")+1:inFile.rfind(".")]
    print(output)
    
    with open(inFile, encoding='utf8') as (file):
        contents = file.readlines()
        
        if(inFile.endswith(".txt")):
            outContent = createHTMLString(filename, contents, stylesheets)
        elif(inFile.endswith(".md")):
            outContent = createMarkdownString(filename, contents, stylesheets)
    
        if not os.path.exists(output):
            os.makedirs(output if output.endswith("/") else output + "/")
        
        outputFile = open(output + "/" + filename + ".html", "w", encoding="utf-8")
        outputFile.write(outContent)
        outputFile.close()
        print("\"" + filename + ".html\" generated successfully!")
```

### createMarkdownString()
This function simply calls createHTMLString() to get the base html with title, paragraphs, and stylesheets. The returned html content is then parsed using regex to find and replace markdown patterns with their html counterparts. Regex seemed like the best way to find the markdown patterns in this case.

```python
# Create HTML from markdown file
def createMarkdownString(filename, contents, stylesheets):
    # Create title, paragraphs, and stylesheet first, like normal
    htmlContent = createHTMLString(filename, contents, stylesheets)
    
    # Parse markdown
    htmlContent = re.sub('\*\*([^\ \*.]{1}.*?)\*\*', r'<strong>\1</strong>', htmlContent)
    htmlContent = re.sub('\*([^\ \*.]{1}.*?)\*', r'<em>\1</em>', htmlContent)
    htmlContent = re.sub('\[(.+)\]\((.+)\)', r'<a href="\2">\1</a>', htmlContent)
    
    return htmlContent
```

### Regex
As a reference, this is the explanation for the first regex pattern ```\*\*([^\ \*.]{1}.*?)\*\*```.
![image](https://user-images.githubusercontent.com/86167097/134413477-92996265-b30f-4c6d-8a0e-73ff737ac776.png)

### Readme
README.md now indicates that markdown is supported.
